### PR TITLE
Fix product policy, to let users view products if they are purchasable

### DIFF
--- a/src/Policies/ProductPolicy.php
+++ b/src/Policies/ProductPolicy.php
@@ -31,7 +31,8 @@ class ProductPolicy
 
     public function view(User $user, Product $product)
     {
-        return $user->can(CartPermissionsEnum::LIST_ALL_PRODUCTS) || ($user->can(CartPermissionsEnum::LIST_PURCHASABLE_PRODUCTS) && $this->productService->productIsPurchasableOrOwnedByUser($product, $user));
+        return $user->can(CartPermissionsEnum::LIST_ALL_PRODUCTS)
+            || ($user->can(CartPermissionsEnum::LIST_PURCHASABLE_PRODUCTS) && $this->productService->productIsPurchasableOrOwnedByUser($product, $user));
     }
 
     public function buy(User $user, Product $product)

--- a/src/Policies/ProductPolicy.php
+++ b/src/Policies/ProductPolicy.php
@@ -31,8 +31,7 @@ class ProductPolicy
 
     public function view(User $user, Product $product)
     {
-        return $user->can(CartPermissionsEnum::LIST_ALL_PRODUCTS)
-            || ($user->can(CartPermissionsEnum::LIST_PURCHASABLE_PRODUCTS) && $this->productService->productIsBuyableOrOwnedByUser($product, $user));
+        return $user->can(CartPermissionsEnum::LIST_ALL_PRODUCTS) || ($user->can(CartPermissionsEnum::LIST_PURCHASABLE_PRODUCTS) && $this->productService->productIsPurchasableOrOwnedByUser($product, $user));
     }
 
     public function buy(User $user, Product $product)

--- a/src/Services/Contracts/ProductServiceContract.php
+++ b/src/Services/Contracts/ProductServiceContract.php
@@ -28,7 +28,7 @@ interface ProductServiceContract
 
     public function searchAndPaginateProducts(ProductsSearchDto $searchDto, ?OrderDto $orderDto = null): LengthAwarePaginator;
 
-    public function productIsBuyableOrOwnedByUser(Product $product, User $user, bool $check_productables = false);
+    public function productIsPurchasableOrOwnedByUser(Product $product, User $user): bool;
     public function productIsBuyableByUser(Product $product, User $user, bool $check_productables = false);
     public function productIsOwnedByUser(Product $product, User $user, bool $check_productables = false);
     public function productProductablesAllOwnedByUser(Product $product, User $user): bool;

--- a/src/Services/ProductService.php
+++ b/src/Services/ProductService.php
@@ -152,9 +152,9 @@ class ProductService implements ProductServiceContract
         return $query->paginate($searchDto->getPerPage() ?? 15);
     }
 
-    public function productIsBuyableOrOwnedByUser(Product $product, User $user, bool $check_productables = false): bool
+    public function productIsPurchasableOrOwnedByUser(Product $product, User $user): bool
     {
-        return $this->productIsBuyableByUser($product, $user, $check_productables) || $this->productIsOwnedByUser($product, $user, $check_productables);
+        return $product->purchasable || $this->productIsOwnedByUser($product, $user);
     }
 
     public function productIsOwnedByUser(Product $product, User $user, bool $check_productables = false): bool
@@ -179,6 +179,7 @@ class ProductService implements ProductServiceContract
         $is_under_limit_total = is_null($limit_total) || (($product->users_count ?? $product->users()->count()) < $limit_total);
         $is_productables_buyable = !$check_productables || $this->productProductablesAllBuyableByUser($product, $user);
         Log::debug(__('Checking if product is buyable'), [
+            'user' => $user->getKey(),
             'product' => [
                 'id' => $product->getKey(),
                 'name' => $product->name,


### PR DESCRIPTION
Fix product policy, to let users view products if they are purchasable (public) or owned by them; don't return 403 http error when product is not buyable as it does not matter for getting product details